### PR TITLE
Make serde an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,12 @@ keywords = ["jep106", "embedded"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 std = []
+serde = ["std", "dep:serde"]
 
-[dependencies]
-serde = { version = "1.0.101", default-features = false, features = ["derive"] }
+[dependencies.serde]
+version = "1.0.101"
+default-features = false
+features = ["derive"]
+optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,14 @@
 
 mod codes;
 
-#[macro_use]
-extern crate serde;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 pub use codes::version;
 
 /// A Struct which contains a fully qualified JEP106 manufacturer code.
-#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct JEP106Code {
     /// JEP106 identification code.
     /// Points to a manufacturer name in the bank table corresponding to `cc`.


### PR DESCRIPTION
It seems the `Deserialize` and `Serialize` impls aren't used within the crate and are for consumers. This PR makes them optional for users that don't want `serde` as a dependency.